### PR TITLE
UPDATE BugzillaTicket to accept auth as tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ the Requests session with `t.close_requests_session()`.
 
 #### Create JIRA ticket
 ```python
-import TicketUtil
+from TicketUtil import JiraTicket
 
 # Create a ticket object and pass the url and project key in as strings.
-t = TicketUtil.JiraTicket(<jira_url>, <project_key>)
+t = JiraTicket(<jira_url>, <project_key>)
 
 # Create our params for ticket creation.
 params = {'summary': 'Ticket Title',
@@ -121,10 +121,10 @@ t.close_requests_session()
 
 #### Update JIRA ticket
 ```python
-import TicketUtil
+from TicketUtil import JiraTicket
 
 # Create a ticket object and pass the url, project key, and ticket id in as strings.
-t = TicketUtil.JiraTicket(<jira_url>, <project_key>, <ticket_id>)
+t = JiraTicket(<jira_url>, <project_key>, <ticket_id>)
 
 # Update ticket.
 t.update('Update ticket with this comment')
@@ -138,10 +138,10 @@ t.close_requests_session()
 
 #### Resolve JIRA ticket
 ```python
-import TicketUtil
+from TicketUtil import JiraTicket
 
 # Create a ticket object and pass the url, project key, and ticket id in as strings.
-t = TicketUtil.JiraTicket(<jira_url>, <project_key>, <ticket_id>)
+t = JiraTicket(<jira_url>, <project_key>, <ticket_id>)
 
 # Resolve ticket with transition id of '3'.
 t.resolve('3')
@@ -178,10 +178,10 @@ closing the Requests session with `t.close_requests_session()`.
 
 #### Create RT ticket
 ```python
-import TicketUtil
+from TicketUtil import RTTicket
 
 # Create a ticket object and pass the url and project queue in as strings.
-t = TicketUtil.RTTicket(<rt_url>, <project_queue>)
+t = RTTicket(<rt_url>, <project_queue>)
 
 # Create our params for ticket creation.
 params = {'Subject': 'Ticket Title',
@@ -200,8 +200,10 @@ t.close_requests_session()
 
 #### Update RT ticket
 ```python
+from TicketUtil import RTTicket
+
 # Create a ticket object and pass the url, project queue, and ticket id in as strings.
-t = TicketUtil.RTTicket(<rt_url>, <project_queue>, <ticket_id>)
+t = RTTicket(<rt_url>, <project_queue>, <ticket_id>)
 
 # Update ticket.
 t.update('Update ticket with this comment')
@@ -215,10 +217,10 @@ t.close_requests_session()
 
 #### Resolve RT ticket
 ```python
-import TicketUtil
+from TicketUtil import RTTicket
 
 # Create a ticket object and pass the url, project queue, and ticket id in as strings.
-t = TicketUtil.RTTicket(<rt_url>, <project_queue>, <ticket_id>)
+t = RTTicket(<rt_url>, <project_queue>, <ticket_id>)
 
 # Resolve ticket.
 t.resolve()
@@ -236,7 +238,7 @@ key passed in as a username with a random password for `<password>`. For
 more details, see http://www.redmine.org/projects/redmine/wiki/Rest_api#Authentication.
 
 ```python
->>> from TicketUtil import RTTicket
+>>> from TicketUtil import RedmineTicket
 >>> t = RedmineTicket(<redmine_url>, <project_name>, auth=(<username>, <password>))
 ```
 
@@ -257,7 +259,7 @@ closing the Requests session with `t.close_requests_session()`.
 
 #### Create Redmine ticket
 ```python
-import TicketUtil
+from TicketUtil import RedmineTicket
 
 # Create a ticket object and pass the url and project name in as strings, and the auth in as a tuple.
 t = RedmineTicket(<redmine_url>, <project_name>, auth=(<username>, <password>))
@@ -279,7 +281,7 @@ t.close_requests_session()
 
 #### Update Redmine ticket
 ```python
-import TicketUtil
+from TicketUtil import RedmineTicket
 
 # Create a ticket object and pass the url, project name, and ticket id in as strings, and the auth in as a tuple.
 t = RedmineTicket(<redmine_url>, <project_name>, <ticket_id>, auth=(<username>, <password>))
@@ -296,7 +298,7 @@ t.close_requests_session()
 
 #### Resolve Redmine ticket
 ```python
-import TicketUtil
+from TicketUtil import RedmineTicket
 
 # Create a ticket object and pass the url, project name, and ticket id in as strings, and the auth in as a tuple.
 t = RedmineTicket(<redmine_url>, <project_name>, <ticket_id>, auth=(<username>, <password>))
@@ -310,44 +312,45 @@ t.close_requests_session()
 
 ### Bugzilla
 
-Currently, Bugzilla supports Kerberos as well as authentication with 
-general login name and password. In the code general login will allow 
+Currently, Bugzilla supports Kerberos as well as HTTP Basic 
+authentication. For basic authentication, pass in your username and 
+password as a tuple into the auth argument. This will allow 
 you to retrieve a token that can be used as authentication for 
 subsequent API calls. For more details, 
-see : http://bugzilla.readthedocs.io/en/latest/api/index.html
-Below is the scenario which has been used while passing the general
-username and passowrd setting the authentication method as auth=rest.
-For kerberos you have to pass the parameter for auth=kerberos while 
-keeping other values to NONE.
+see: http://bugzilla.readthedocs.io/en/latest/api/index.html.
+
+The examples below use basic authentication. For kerberos, set 
+`auth="kerberos"` when creating a BugzillaTicket object.
 
 ```python
->>> from TicketUtil import RTTicket
->>> t = BugzillaTicket('<bugzilla_url>','<product_name>', 'None', 'rest', username, password)
+>>> from TicketUtil import BugzillaTicket
+>>> t = BugzillaTicket(<bugzilla_url>, <product_name>, auth=(<username>, <password>))
 ```
 
 You should see the following response:
 ```python
 INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): <bugzilla_url>
 INFO:root:Successfully authenticated to Bugzilla with token: <token-id>
-
 ```
-You now have a BugzillaTicket object that is associated with the <product_name>.
-Some example workflows are found below. Notice that they all start with creating a BugzillaTicket object associated with a project (and with a ticket id when updating / resolving tickets). The last step is always closing the Requests session with t.close_requests_session().
-Check the details call below and execute accordingly in python:
+You now have a `BugzillaTicket` object that is associated with the 
+`<product_name>` product.
+
+Some example workflows are found below. Notice that they all start with 
+creating a BugzillaTicket object associated with a product (and with a 
+ticket id when updating / resolving tickets). The last step is always 
+closing the Requests session with `t.close_requests_session()`.
 
 #### Create Bugzilla ticket
 ```python
-import TicketUtil
+from TicketUtil import BugzillaTicket
 
-# Create a ticket object and pass the url, product_name as strings additionally set the environment variable for the username and password.
-t = BugzillaTicket('<bugzilla_url>','<product_name>', 'None', 'rest', username, password)
+# Create a ticket object and pass the url and product_name in as strings, and the auth in as a tuple.
+t = BugzillaTicket(<bugzilla_url>, <product_name>, auth=(<username>, <password>))
 
 # Create our params for ticket creation.
-params = {"product" : "TestProduct",
-          "component" : "TestComponent",
+params = {"component" : "TestComponent",
           "version" : "unspecified",
           "summary" : "'This is a test bug - please disregard"}
-
 
 # Create our ticket.
 t.create(params)
@@ -357,15 +360,14 @@ t.add_comment("Test Comment")
 
 # Close Requests session.
 t.close_requests_session()
-
 ```
 
 #### Update Bugzilla ticket
 ```python
-import TicketUtil
+from TicketUtil import BugzillaTicket
 
-# Create a ticket object and pass the url, product_name and exsisting ticket-id in as strings.
-t = BugzillaTicket('<bugzilla_url>','<product_name>', '<existing-ticket-id>', 'rest', username, password)
+# Create a ticket object and pass the url, product_name and exsisting ticket-id in as strings, and the auth in as a tuple.
+t = BugzillaTicket(<bugzilla_url>, <product_name>, <ticket_id>, auth=(<username>, <password>))
 
 # Add a new comment.
 t.add_comment('Add a second comment to ticket')
@@ -376,12 +378,12 @@ t.close_requests_session()
 
 #### Edit Bugzilla ticket 
 ```python
-import TicketUtil
+from TicketUtil import BugzillaTicket
 
 # Create a ticket object and pass the url, product_name and exsisting ticket-id in as strings.
-t = BugzillaTicket('<bugzilla_url>','<product_name>', '<existing-ticket-id>', 'rest', username, password)
+t = BugzillaTicket(<bugzilla_url>, <product_name>, <ticket_id>, auth=(<username>, <password>))
 
-# Edit the ticket fields by specifying the edit ticket dictonary with the valid feilds, below are the example fields they may differ as per need.
+# Edit the ticket fields by specifying the edit ticket dictonary with valid fields. 
 edit_ticket_dict = {'summary': '[Update]This is a test bug - please disregard',
                     'product': '<product-name>',
                     'component': '<product-component>',
@@ -396,13 +398,14 @@ t.close_requests_session()
 
 #### Resolve Bugzilla ticket
 ```python
-import TicketUtil
+from TicketUtil import BugzillaTicket
 
 # Create a ticket object and pass the url, product_name and exsisting ticket-id in as strings.
-t = BugzillaTicket('<bugzilla_url>','<product_name>', '<existing-ticket-id>', 'rest', username, password)
+t = BugzillaTicket(<bugzilla_url>, <product_name>, <ticket_id>, auth=(<username>, <password>))
 
-# Resolve the ticket with proper status and resolution aditionally note that if a bug is changing from open to closed, you should also specify a resolution, else it can be specified to "NONE".
-resolve_params = {"status": "<status>", "resolution": "<resolution>"}
+# Resolve the ticket with proper status and resolution.
+# Additionally note that if a bug is changing from open to closed, you should also specify a resolution, else it can be specified to "NONE".
+resolve_params = {"status": <status>, "resolution": <resolution>}
 t.transition_ticket(resolve_params)
 
 # Close Requests session.

--- a/TicketUtil.py
+++ b/TicketUtil.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import os
 
 import gssapi
 import requests
@@ -11,7 +10,7 @@ __author__ = 'dranck, rnester, kshirsal'
 # Disable warnings for requests because we aren't doing certificate verification
 requests.packages.urllib3.disable_warnings()
 
-DEBUG = True
+DEBUG = False
 
 if DEBUG:
     logging.basicConfig(level=logging.DEBUG)
@@ -127,14 +126,18 @@ class BugzillaTicket(Ticket):
     """
     A BZ Ticket object. Contains BZ-specific methods for working with tickets.
     """
-
-    def __init__(self, base_url, project_key, ticket_id=None, auth=None, user=None, password=None):
+    def __init__(self, base_url, project_key, ticket_id=None, auth=None):
         self.ticketing_tool = 'Bugzilla'
 
-        # Right now, hardcode auth as 'kerberos', which is the only supported auth for BZ.
-        self.auth = auth if auth else 'kerberos'
+        # Kerberos is default auth if the auth param is not specified.
+        # A tuple of the form (<username>, <password>) can also be passed in.
+        if isinstance(auth, tuple):
+            self.auth = auth
+            username, password = auth
+            self.credentials = {"login": username, "password": password}
+        else:
+            self.auth = 'kerberos'
 
-        self.credentials = {"login": user, "password": password}
         self.token = None
 
         # BZ URLs
@@ -188,9 +191,10 @@ class BugzillaTicket(Ticket):
         We're using a Session to persist cookies across all requests made from the Session instance.
         :return s: Requests Session.
         """
-        if self.auth != 'rest':
-            return super()
+        if self.auth == 'kerberos':
+            return super(BugzillaTicket, self).create_requests_session()
 
+        # If basic authentication is passed in, generate a token to be used in all requests.
         try:
             s = requests.Session()
             r = s.get(self.auth_url, params=self.credentials, verify=False)
@@ -198,11 +202,12 @@ class BugzillaTicket(Ticket):
             resp = r.json()
             self.token = resp['token']
             logging.debug("Create requests session: Status Code: {0}".format(r.status_code))
-            logging.info("Successfully authenticated to {0} with token: {1}".format(self.ticketing_tool, self.token))
+            logging.info("Successfully authenticated to {0}.".format(self.ticketing_tool))
             return s
 
         # We log an error if authentication was not successful, because rest of the HTTP requests will not succeed.
-        except requests.RequestException as e:
+        # If authentication wasn't successful, a token will not be in resp. Add KeyError as exception.
+        except (KeyError, requests.RequestException) as e:
             logging.error("Error authenticating to {0}. No valid credentials were provided.".format(self.auth_url))
             logging.error(e.args[0])
 
@@ -887,6 +892,7 @@ class RedmineTicket(Ticket):
         else:
             logging.error("No ticket ID associated with ticket object. Set ticket ID with set_ticket_id(ticket_id)")
 
+
 def get_kerberos_principal():
     """
     Use gssapi to get the current kerberos principal.
@@ -897,6 +903,7 @@ def get_kerberos_principal():
         return str(gssapi.Credentials(usage='initiate').name).lower()
     except gssapi.raw.misc.GSSError:
         return None
+
 
 def main():
     """


### PR DESCRIPTION
Instead of having auth, username, and password parameters for Bugzilla,
this code makes it more consistent with RedmineTicket, which accepts a
tuple for auth of the form auth=(username, password).

Make README more consistent across all four tools.